### PR TITLE
[example] Preserve node expanded/collapsed state in additional data structure

### DIFF
--- a/app/components/AddRelatedForm.jsx
+++ b/app/components/AddRelatedForm.jsx
@@ -7,11 +7,24 @@ export default class AddRelatedForm extends React.Component {
 
     constructor(props) {
       super(props);
+
       this.state = {
         suggestingRelations: false,
-        filter:'',
-        expandedRelatedIdeas:{}
+        filter: '',
+        expandedRelatedIdeas: this._getExpandedIdeasFromNodeState()
       }
+    }
+
+    _getExpandedIdeasFromNodeState = () => {
+      if (!this.props.nodeState.expandedRelatedIdeas) {
+        this.props.nodeState.expandedRelatedIdeas = {}
+      }
+
+      return Object.assign({}, this.props.nodeState.expandedRelatedIdeas)
+    }
+
+    _setExpandedIdeasToNodeState = (newExpandedIdeas) => {
+      this.props.nodeState.expandedRelatedIdeas = newExpandedIdeas
     }
 
     relateToCurrentIdea = (targetId) => {
@@ -44,10 +57,22 @@ export default class AddRelatedForm extends React.Component {
       suggestions = filterEntries(suggestions, this.state.filter)
 
       return suggestions
-
     }
 
+    toggleRelatedNoteDisplay = (relation) => {
+      const expandedRelatedIdeas = this._getExpandedIdeasFromNodeState()
+      const relatedNoteId = relation.targetId
+      const currentRelatedIdeaExpansionState = expandedRelatedIdeas[relatedNoteId]
+      const toggledExpansionState = currentRelatedIdeaExpansionState ? undefined : true
 
+      expandedRelatedIdeas[relatedNoteId] = toggledExpansionState
+
+      this._setExpandedIdeasToNodeState(expandedRelatedIdeas)
+
+      this.setState({
+        expandedRelatedIdeas: expandedRelatedIdeas
+      })
+    }
 
     createAndRelate = (text) => {
       const newNoteId = this.props.addNote(text);
@@ -119,12 +144,8 @@ export default class AddRelatedForm extends React.Component {
           {/* output related notes list */ }
           <span style={{ marginLeft: "150px", lineHeight:"21px" }}>
             {relatedNotes.map( ({broken, note, relation}) =>
-              <span key={"relatedNote" + relation.id} 
-                  onClick={ () => 
-                    this.setState({expandedRelatedIdeas:
-                        Object.assign({}, this.state.expandedRelatedIdeas, {[relation.targetId]: this.state.expandedRelatedIdeas[relation.targetId] ? undefined : true})
-                    }) 
-                  } 
+              <span key={"relatedNote" + relation.id}
+                  onClick={() => this.toggleRelatedNoteDisplay(relation)}
                   style={
                     Object.assign(
                     {margin: "0 5px", padding: "1px 5px", fontFamily: "Arial, sans serif", fontSize: "12px"}
@@ -169,6 +190,7 @@ export default class AddRelatedForm extends React.Component {
             addRelation={this.props.addRelation}
             addNote={this.props.addNote}
             editNote={this.props.editNote}
+            parentNodeState={this.props.nodeState}
             allNotes={this.props.allNotes}
             filteredNotes={this.props.allNotes.filter(x => {
               console.log(x.id, !!this.state.expandedRelatedIdeas[x.id])
@@ -192,6 +214,7 @@ AddRelatedForm.propTypes = {
   relateToCurrentIdea: React.PropTypes.func.isRequired,
   addNote: React.PropTypes.func.isRequired,
   note: React.PropTypes.object.isRequired,
+  nodeState: React.PropTypes.isRequired,
 
   addRelation: React.PropTypes.func.isRequired,
   relations: React.PropTypes.array.isRequired,

--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -5,6 +5,7 @@ import Node from './Node.jsx'
 import uuid from 'node-uuid'
 import * as d3 from "d3";
 
+import NodeState from './NodeState'
 
 import { encodeHtmlEntity, filterEntries, seededRandom } from './utils.js'
 
@@ -22,7 +23,9 @@ export default class App extends React.Component {
             ],
              playTimeoutId:null
     }
-    
+
+    this._rootNodeState = new NodeState()
+
 
     // relation:
     // {
@@ -606,6 +609,7 @@ if(!d)
           filteredNotes={filterEntries(this.state.notes, this.state.filter)}
           relations={relations}
           rawRelations={this.state.rawRelations}
+          parentNodeState={this._rootNodeState}
           />
    
         </div>

--- a/app/components/NodeState.js
+++ b/app/components/NodeState.js
@@ -5,11 +5,11 @@ export default class NodeState {
     this._childStates = {}
   }
 
-  getChildState (id) {
-    if (!this._childStates[id]) {
-      this._childStates[id] = new NodeState()
+  getChildState (nodeKey) {
+    if (!this._childStates[nodeKey]) {
+      this._childStates[nodeKey] = new NodeState()
     }
 
-    return this._childStates[id]
+    return this._childStates[nodeKey]
   }
 }

--- a/app/components/NodeState.js
+++ b/app/components/NodeState.js
@@ -1,0 +1,15 @@
+// TODO: move to more appropriate location
+
+export default class NodeState {
+  constructor () {
+    this._childStates = {}
+  }
+
+  getChildState (id) {
+    if (!this._childStates[id]) {
+      this._childStates[id] = new NodeState()
+    }
+
+    return this._childStates[id]
+  }
+}

--- a/app/components/Note.jsx
+++ b/app/components/Note.jsx
@@ -58,6 +58,7 @@ export default class Note extends React.Component {
     {todoDiv}
     <AddRelatedForm
       note={this.props.note}
+      nodeState={this.props.nodeState}
       rawRelations={this.props.rawRelations}
       relatedNotes={this.props.relatedNotes}
       relateToCurrentIdea={ (targetId) => this.props.addRelation(id, targetId) }
@@ -75,6 +76,7 @@ export default class Note extends React.Component {
 Note.propTypes = {
 
   note: React.PropTypes.object.isRequired,
+  nodeState: React.PropTypes.isRequired,
   rawRelations: React.PropTypes.bool.isRequired,
   relatedNotes: React.PropTypes.array.isRequired,
   editNote: React.PropTypes.func.isRequired,

--- a/app/components/Notes.jsx
+++ b/app/components/Notes.jsx
@@ -14,6 +14,7 @@ export default class Notes extends React.Component {
                             <li key={note.id} style={{margin:"10px"}}>
                                 <Note
                                   editNote={this.props.editNote}
+                                  nodeState={this.props.parentNodeState.getChildState(note.id)}
                                   note={note}
                                   allNotes={this.props.allNotes}
                                   addRelation={this.props.addRelation}
@@ -50,6 +51,7 @@ export default class Notes extends React.Component {
 
 Notes.propTypes = {
   editNote: React.PropTypes.func.isRequired,
+  parentNodeState: React.PropTypes.isRequired,
   addRelation: React.PropTypes.func.isRequired,
   addNote: React.PropTypes.func.isRequired,
   filteredNotes: React.PropTypes.array.isRequired,


### PR DESCRIPTION
- add structure to preserve arbitrary node state even after node gets destroyed;
- use it to preserve list of expanded nodes